### PR TITLE
Check that openssl, yaml, readline, zlib are all loadable

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -834,15 +834,38 @@ build_package_mac_openssl() {
 
 # Post-install check that the openssl extension was built.
 build_package_verify_openssl() {
-  "$RUBY_BIN" -e 'begin
-    require "openssl"
-  rescue LoadError
-    $stderr.puts "The Ruby openssl extension was not compiled. Missing the OpenSSL lib?"
-    $stderr.puts "Configure options used:"
-    require "rbconfig"; require "shellwords"
-    RbConfig::CONFIG.fetch("configure_args").shellsplit.each { |arg| $stderr.puts "  #{arg}" }
-    exit 1
-  end' >&4 2>&1
+  "$RUBY_BIN" -e '
+    manager = ARGV[0]
+    packages = {
+      "apt-get" => Hash.new {|h,k| "lib#{k}-dev" }.update(
+        "openssl" => "libssl-dev",
+        "zlib" => "zlib1g-dev"
+      ),
+      "yum" => Hash.new {|h,k| "#{k}-devel" }.update(
+        "yaml" => "libyaml-devel"
+      )
+    }
+
+    failed = %w[openssl readline zlib yaml].reject do |lib|
+      begin
+        require lib
+      rescue LoadError
+        $stderr.puts "The Ruby #{lib} extension was not compiled."
+      end
+    end
+
+    if failed.size > 0
+      $stderr.puts "ERROR: Ruby install aborted due to missing extensions"
+      $stderr.print "Try running `%s install -y %s` to fetch missing dependencies.\n\n" % [
+        manager,
+        failed.map { |lib| packages.fetch(manager)[lib] }.join(" ")
+      ] unless manager.empty?
+      $stderr.puts "Configure options used:"
+      require "rbconfig"; require "shellwords"
+      RbConfig::CONFIG.fetch("configure_args").shellsplit.each { |arg| $stderr.puts "  #{arg}" }
+      exit 1
+    end
+  ' "$(basename "$(type -p yum apt-get | head -1)")" >&4 2>&1
 }
 
 # Ensure that directories listed in LDFLAGS exist


### PR DESCRIPTION
Before, we detected whether `require "openssl"` works after compiling Ruby 2.0.0+ and failed the build if the openssl extension never compiled. This change extends this practice to zlib, yaml and readline as well since we consider these to be essential packages for most Ruby development. Rubygems won't work, for instance, without zlib.

This also suggests how you could install necessary dependencies if a package manager `apt-get` or `yum` is detected on the system.

Example output:

    The Ruby zlib extension was not compiled.
    The Ruby openssl extension was not compiled.
    ERROR: Ruby install aborted due to missing extensions
    Try running `apt-get install -y libssl-dev zlib1g-dev` to fetch missing dependencies

Pros:

- Detects stuff like #509 or #557 and aborts the install
- Tells you how you can use your package manager to fetch the missing dependency

Cons:

- Maybe some people don't need stuff like readline or zlib and are fine if these aren't compiled?
- With this, `verify_openssl` function becomes a misnomer since it verifies more stuff than just openssl.

How does everyone feel about this?