### PR TITLE
Skip `ldflags_dirs` step for Rubies where it's not necessary

### DIFF
--- a/share/ruby-build/2.1.0
+++ b/share/ruby-build/2.1.0
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.1h" "https://www.openssl.org/source/openssl-1.0.1h.tar.gz#9d1c8a9836aa63e2c6adb684186cbd4371c9e9dcc01d6e3bb447abf2d4d3d093" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.1.0" "http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0.tar.gz#3538ec1f6af96ed9deb04e0965274528162726cc9ba3625dcf23648df872d09d" ldflags_dirs standard verify_openssl
+install_package "ruby-2.1.0" "http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0.tar.gz#3538ec1f6af96ed9deb04e0965274528162726cc9ba3625dcf23648df872d09d" standard verify_openssl

--- a/share/ruby-build/2.1.0-preview2
+++ b/share/ruby-build/2.1.0-preview2
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.1h" "https://www.openssl.org/source/openssl-1.0.1h.tar.gz#9d1c8a9836aa63e2c6adb684186cbd4371c9e9dcc01d6e3bb447abf2d4d3d093" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.1.0-preview2" "http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0-preview2.tar.gz#a9b1dbc16090ddff8f6c6adbc1fd0473bcae8c69143cecabe65d55f95f6dbbfb" ldflags_dirs standard verify_openssl
+install_package "ruby-2.1.0-preview2" "http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0-preview2.tar.gz#a9b1dbc16090ddff8f6c6adbc1fd0473bcae8c69143cecabe65d55f95f6dbbfb" standard verify_openssl

--- a/share/ruby-build/2.1.0-rc1
+++ b/share/ruby-build/2.1.0-rc1
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.1h" "https://www.openssl.org/source/openssl-1.0.1h.tar.gz#9d1c8a9836aa63e2c6adb684186cbd4371c9e9dcc01d6e3bb447abf2d4d3d093" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.1.0-rc1" "http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0-rc1.tar.gz#1b467f13be6d3b3648a4de76b34b748781fe4f504a19c08ffa348c75dd62635e" ldflags_dirs standard verify_openssl
+install_package "ruby-2.1.0-rc1" "http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.0-rc1.tar.gz#1b467f13be6d3b3648a4de76b34b748781fe4f504a19c08ffa348c75dd62635e" standard verify_openssl

--- a/share/ruby-build/2.1.1
+++ b/share/ruby-build/2.1.1
@@ -1,3 +1,3 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "openssl-1.0.1h" "https://www.openssl.org/source/openssl-1.0.1h.tar.gz#9d1c8a9836aa63e2c6adb684186cbd4371c9e9dcc01d6e3bb447abf2d4d3d093" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.1.1" "http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.1.tar.gz#c843df31ae88ed49f5393142b02b9a9f5a6557453805fd489a76fbafeae88941" ldflags_dirs standard verify_openssl
+install_package "ruby-2.1.1" "http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.1.tar.gz#c843df31ae88ed49f5393142b02b9a9f5a6557453805fd489a76fbafeae88941" standard verify_openssl


### PR DESCRIPTION
`ldflags_dirs` was added for Ruby 2.1.0-dev in 50bf60f9c2510fbee7f111046e97fe8bf9e66472.

Since then, in releases of Ruby 2.1.x the LDFLAGS checker seems to have gotten more permissive and this step isn't necessary anymore. However, Ruby 2.1.2 and 2.2.0-dev seem to need it still.

This removes `ldflags_dirs` from at least those build definitions where it's not necessary in order to clean them up and avoid cargo-culting.

@hsbt: Why do you think LDFLAGS checker has gotten less strict since 2.1.0 release but has become more strict again in 2.1.2 and onwards?