### PR TITLE
added rubinius 2.3.0 (rbx-2.3.0)

### DIFF
--- a/share/ruby-build/rbx-2.3.0
+++ b/share/ruby-build/rbx-2.3.0
@@ -1,0 +1,2 @@
+require_llvm 3.4
+install_package "rubinius-2.3.0" "http://releases.rubini.us/rubinius-2.3.0.tar.bz2#9953c3af5e9694540859eaf55164a38d0c32c3ad35457e4351d20c28a25fecaa" rbx

--- a/share/ruby-build/rbx-2.3.0
+++ b/share/ruby-build/rbx-2.3.0
@@ -1,2 +1,1 @@
-require_llvm 3.4
 install_package "rubinius-2.3.0" "http://releases.rubini.us/rubinius-2.3.0.tar.bz2#9953c3af5e9694540859eaf55164a38d0c32c3ad35457e4351d20c28a25fecaa" rbx


### PR DESCRIPTION
I added the support for Rubinius 2.3.0 (rbx-2.3.0) using LLVM 3.4
Tested on:

* Ubuntu 15.04 [Vivid Vervet (development branch)]
* rbenv 0.4.0
* ruby-build 20140926

