### PR TITLE
Cleaner error if you have a .rbenv file, not a directory.

### DIFF
--- a/bin/rbenv-install
+++ b/bin/rbenv-install
@@ -26,6 +26,11 @@ set -e
 
 if [ -z "$RBENV_ROOT" ]; then
   RBENV_ROOT="${HOME}/.rbenv"
+  if [ ! -d $RBENV_ROOT ]; then
+    echo "$RBENV_ROOT is not a directory!"
+    echo "'rm $RBENV_ROOT' to fix this issue."
+    exit 1
+  fi
 fi
 
 # Add `share/ruby-build/` directory from each rbenv plugin to the list of

--- a/bin/rbenv-uninstall
+++ b/bin/rbenv-uninstall
@@ -25,6 +25,11 @@ usage() {
 
 if [ -z "$RBENV_ROOT" ]; then
   RBENV_ROOT="${HOME}/.rbenv"
+  if [ ! -d $RBENV_ROOT ]; then
+    echo "$RBENV_ROOT is not a directory!"
+    echo "'rm $RBENV_ROOT' to fix this issue."
+    exit 1
+  fi
 fi
 
 if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then


### PR DESCRIPTION
If you do something incredibly stupid and misread the error generated
from a clean install of rbenv (see *), you might do something like I did
and `touch ~/.rbenv` thinking that will silence the warning. The error
you get when you install ruby-build and subsequently try to install a
ruby is a bit unclear.

There is no real reason this needs to be merged, though it
might be somewhat helpful in case someone else does the same goof.

*: /usr/local/Cellar/rbenv/0.4.0/libexec/rbenv---version: line 17: cd:
/Users/jenkins/.rbenv: No such file or directory