### PR TITLE
removed jruby-9000 definitions

### DIFF
--- a/share/ruby-build/jruby-9000+graal-dev
+++ b/share/ruby-build/jruby-9000+graal-dev
@@ -1,1 +1,0 @@
-install_package "jruby-9.0.0.0-SNAPSHOT" "http://lafo.ssw.uni-linz.ac.at/graalvm/jruby-dist-9.0.0.0-SNAPSHOT+graal-$(graal_architecture)-bin.tar.gz" jruby

--- a/share/ruby-build/jruby-9000-dev
+++ b/share/ruby-build/jruby-9000-dev
@@ -1,2 +1,0 @@
-require_java7
-install_package "jruby-9.0.0.0-SNAPSHOT" "http://ci.jruby.org/snapshots/master/jruby-dist-9.0.0.0-SNAPSHOT-bin.tar.gz" jruby


### PR DESCRIPTION
jruby-9000-* is obsoleted names. it should be removed.