### PR TITLE
Use HTTPS for CloudFront URLs

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1117,7 +1117,7 @@ else
 fi
 
 if [ -z "$RUBY_BUILD_MIRROR_URL" ]; then
-  RUBY_BUILD_MIRROR_URL="http://dqw8nmjcqpjn7.cloudfront.net"
+  RUBY_BUILD_MIRROR_URL="https://dqw8nmjcqpjn7.cloudfront.net"
 else
   RUBY_BUILD_MIRROR_URL="${RUBY_BUILD_MIRROR_URL%/}"
 fi

--- a/test/arguments.bats
+++ b/test/arguments.bats
@@ -2,7 +2,7 @@
 
 load test_helper
 
-@test "not enought arguments for ruby-build" {
+@test "not enough arguments for ruby-build" {
   # use empty inline definition so nothing gets built anyway
   local definition="${TMP}/build-definition"
   echo '' > "$definition"

--- a/test/cache.bats
+++ b/test/cache.bats
@@ -59,7 +59,7 @@ setup() {
 
   stub shasum true "echo invalid" "echo $checksum"
   stub curl "-*I* : true" \
-    "-q -o * -*S* http://?*/$checksum : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3"
+    "-q -o * -*S* https://?*/$checksum : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3"
 
   touch "${RUBY_BUILD_CACHE_PATH}/package-1.0.0.tar.gz"
 

--- a/test/mirror.bats
+++ b/test/mirror.bats
@@ -92,7 +92,7 @@ export RUBY_BUILD_MIRROR_URL=http://mirror.example.com
 
   stub shasum true "echo $checksum"
   stub curl "-*I* : true" \
-    "-q -o * -*S* http://?*/$checksum : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3" \
+    "-q -o * -*S* https://?*/$checksum : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3" \
 
   install_fixture definitions/with-checksum
   [ "$status" -eq 0 ]


### PR DESCRIPTION
Currently ruby-build uses straight HTTP for downloads from CloudFront. Since CloudFront has SSL enabled for any endpoints this is an easy change that should help secure downloads from CloudFront.

Like most CDNs CloudFront does charge slightly more for HTTPS over HTTP but that's probably worth it - if not then feel free to ignore this PR, no harm no foul :-)