### PR TITLE
No longer installs the jruby-launcher gem unless explicitly requested.

### DIFF
--- a/bin/rbenv-install
+++ b/bin/rbenv-install
@@ -16,6 +16,7 @@
 #                      (defaults to $RBENV_ROOT/sources)
 #   -v/--verbose       Verbose mode: print compilation status to stdout
 #   -p/--patch         Apply a patch from stdin before building
+#   --launcher-gem     Install java-launcher gem for jruby
 #
 # For detailed information on installing Ruby versions with
 # ruby-build, including a list of environment variables for adjusting
@@ -65,6 +66,7 @@ unset SKIP_EXISTING
 unset KEEP
 unset VERBOSE
 unset HAS_PATCH
+unset LAUNCHER_GEM
 
 parse_options "$@"
 for option in "${OPTIONS[@]}"; do
@@ -91,6 +93,9 @@ for option in "${OPTIONS[@]}"; do
     ;;
   "p" | "patch" )
     HAS_PATCH="-p"
+    ;;
+  "launcher-gem" )
+    LAUNCHER_GEM="--launcher-gem"
     ;;
   "version" )
     exec ruby-build --version
@@ -191,7 +196,8 @@ trap cleanup SIGINT
 
 # Invoke `ruby-build` and record the exit status in $STATUS.
 STATUS=0
-ruby-build $KEEP $VERBOSE $HAS_PATCH "$DEFINITION" "$PREFIX" || STATUS="$?"
+ruby-build $KEEP $VERBOSE $HAS_PATCH $LAUNCHER_GEM "$DEFINITION" "$PREFIX" \
+    || STATUS="$?"
 
 # Display a more helpful message if the definition wasn't found.
 if [ "$STATUS" == "2" ]; then

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -7,6 +7,7 @@
 #   -v/--verbose     Verbose mode: print compilation status to stdout
 #   -p/--patch       Apply a patch from stdin before building
 #   --definitions    List all built-in definitions
+#   --launcher-gem   Install java-launcher gem for jruby
 #
 
 RUBY_BUILD_VERSION="20150319zf"
@@ -597,7 +598,7 @@ build_package_jruby() {
   cd "${PREFIX_PATH}/bin"
   ln -fs jruby ruby
   chmod +x ruby
-  install_jruby_launcher
+  [ -z "$LAUNCHER_GEM" ] || install_jruby_launcher
   remove_windows_files
   fix_jruby_shebangs
 }
@@ -1004,6 +1005,7 @@ sort_versions() {
 unset VERBOSE
 unset KEEP_BUILD_PATH
 unset HAS_PATCH
+unset LAUNCHER_GEM
 
 RUBY_BUILD_INSTALL_PREFIX="$(abs_dirname "$0")/.."
 
@@ -1023,6 +1025,9 @@ for option in "${OPTIONS[@]}"; do
   "definitions" )
     list_definitions
     exit 0
+    ;;
+  "launcher-gem" )
+    LAUNCHER_GEM=true
     ;;
   "k" | "keep" )
     KEEP_BUILD_PATH=true


### PR DESCRIPTION
Since jruby already comes with launch scripts, jruby-launcher isn't
really necessary.  It does, however completely scuttle the
installation if the compile fails.

This change skips the installation of jruby-launcher unless the
install command was invoked with the flag '--launcher-gem'.

This is a fix for issue:

<https://github.com/sstephenson/ruby-build/issues/734>.