### PR TITLE
Add 'cd -' to proposed steps to upgrade ruby-build

### DIFF
--- a/bin/rbenv-install
+++ b/bin/rbenv-install
@@ -211,7 +211,7 @@ if [ "$STATUS" == "2" ]; then
       echo "  brew update && brew upgrade ruby-build"
     elif [ -d "${here}/.git" ]; then
       printf ":\n\n"
-      echo "  cd ${here} && git pull"
+      echo "  cd ${here} && git pull && cd -"
     else
       printf ".\n"
     fi

--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -69,7 +69,7 @@ See all available versions with \`rbenv install --list'.
 
 If the version you need is missing, try upgrading ruby-build:
 
-  cd ${BATS_TEST_DIRNAME}/.. && git pull
+  cd ${BATS_TEST_DIRNAME}/.. && git pull && cd -
 OUT
 
   unstub ruby-build


### PR DESCRIPTION
When a target is not found, rbenv-install proposes pulling changes from
upstream. This involves changing the directory to the ruby-build checkout.

This patch adds a '&& cd -' to change the working directory back to where
we've been. Should work on at least Bash and Zsh.