### PR TITLE
Add 2.2.2, 2.1.6 and 2.0.0-p645 but they work

### DIFF
--- a/share/ruby-build/2.0.0-p645
+++ b/share/ruby-build/2.0.0-p645
@@ -1,0 +1,2 @@
+install_package "openssl-1.0.1m" "https://www.openssl.org/source/openssl-1.0.1m.tar.gz#095f0b7b09116c0c5526422088058dc7e6e000aa14d22acca6a4e2babcdfef74" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.0.0-p645" "http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p645.tar.gz#2dcdcf9900cb923a16d3662d067bc8c801997ac3e4a774775e387e883b3683e9" standard verify_openssl

--- a/share/ruby-build/2.0.0-p645
+++ b/share/ruby-build/2.0.0-p645
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.1m" "https://www.openssl.org/source/openssl-1.0.1m.tar.gz#095f0b7b09116c0c5526422088058dc7e6e000aa14d22acca6a4e2babcdfef74" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.0.0-p645" "http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p645.tar.gz#2dcdcf9900cb923a16d3662d067bc8c801997ac3e4a774775e387e883b3683e9" standard verify_openssl
+install_package "ruby-2.0.0-p645" "http://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p645.tar.gz#5e9f8effffe97cba5ef0015feec6e1e5f3bacf6ace78cd1cdf72708cd71cf4ab" standard verify_openssl

--- a/share/ruby-build/2.1.6
+++ b/share/ruby-build/2.1.6
@@ -1,0 +1,2 @@
+install_package "openssl-1.0.1m" "https://www.openssl.org/source/openssl-1.0.1m.tar.gz#095f0b7b09116c0c5526422088058dc7e6e000aa14d22acca6a4e2babcdfef74" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.1.6" "http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.6.tar.gz#7b5233be35a4a7fbd64923e42efb70b7bebd455d9d6f9d4001b3b3a6e0aa6ce9" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.6
+++ b/share/ruby-build/2.1.6
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.1m" "https://www.openssl.org/source/openssl-1.0.1m.tar.gz#095f0b7b09116c0c5526422088058dc7e6e000aa14d22acca6a4e2babcdfef74" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.1.6" "http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.6.tar.gz#7b5233be35a4a7fbd64923e42efb70b7bebd455d9d6f9d4001b3b3a6e0aa6ce9" ldflags_dirs standard verify_openssl
+install_package "ruby-2.1.6" "http://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.6.tar.gz#1e1362ae7427c91fa53dc9c05aee4ee200e2d7d8970a891c5bd76bee28d28be4" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.2.2
+++ b/share/ruby-build/2.2.2
@@ -1,0 +1,2 @@
+install_package "openssl-1.0.1m" "https://www.openssl.org/source/openssl-1.0.1m.tar.gz#095f0b7b09116c0c5526422088058dc7e6e000aa14d22acca6a4e2babcdfef74" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.2.2" "http://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.2.tar.gz#5ffc0f317e429e6b29d4a98ac521c3ce65481bfd22a8cf845fa02a7b113d9b44" ldflags_dirs standard verify_openssl


### PR DESCRIPTION
Updated the checksums in PR #738 which was done a few hours ago but went unnoticed. 

This really is rather important folks, lots of people rely on ruby-build for their versions and today is panic security update day, so it would be great to merge this. 