### PR TITLE
SSL/TLSize all the things! (convert http:// to https:// where possible)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Example usage:
 $ rbenv install --patch 1.9.3-p429 < /path/to/ruby.patch
 
 # applying a patch from HTTP
-$ rbenv install --patch 1.9.3-p429 < <(curl -sSL http://git.io/ruby.patch)
+$ rbenv install --patch 1.9.3-p429 < <(curl -sSL https://git.io/ruby.patch)
 
 # applying multiple patches
 $ cat fix1.patch fix2.patch | rbenv install --patch 1.9.3-p429
@@ -179,7 +179,7 @@ mirror and use official URLs instead. You can force ruby-build to bypass the
 mirror by setting the `RUBY_BUILD_SKIP_MIRROR` environment variable.
 
 The official ruby-build download mirror is sponsored by
-[37signals](http://37signals.com/).
+[Basecamp](https://basecamp.com/).
 
 ### Package download caching
 

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1139,7 +1139,7 @@ else
 fi
 
 if [ -z "$RUBY_BUILD_MIRROR_URL" ]; then
-  RUBY_BUILD_MIRROR_URL="http://dqw8nmjcqpjn7.cloudfront.net"
+  RUBY_BUILD_MIRROR_URL="https://dqw8nmjcqpjn7.cloudfront.net"
 else
   RUBY_BUILD_MIRROR_URL="${RUBY_BUILD_MIRROR_URL%/}"
 fi

--- a/share/ruby-build/1.8.6-p383
+++ b/share/ruby-build/1.8.6-p383
@@ -1,3 +1,3 @@
 require_gcc
 install_package "ruby-1.8.6-p383" "http://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p383.tar.gz#cea6c67f737727007ec89d1c93fd7d0dba035220f981706091b8642d7a43c03a" auto_tcltk standard
-install_package "rubygems-1.3.7" "http://production.cf.rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby
+install_package "rubygems-1.3.7" "https://d2chzxaqi4y7f8.cloudfront.net/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.6-p420
+++ b/share/ruby-build/1.8.6-p420
@@ -1,3 +1,3 @@
 require_gcc
 install_package "ruby-1.8.6-p420" "http://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p420.tar.gz#118e6f24afce8e8a10dced23635168e58da6c9121a21f120c82f425d40a1e321" auto_tcltk standard
-install_package "rubygems-1.3.7" "http://production.cf.rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby
+install_package "rubygems-1.3.7" "https://d2chzxaqi4y7f8.cloudfront.net/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.7-p249
+++ b/share/ruby-build/1.8.7-p249
@@ -1,3 +1,3 @@
 require_gcc
 install_package "ruby-1.8.7-p249" "http://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p249.tar.gz#a969f5ec00f096f01650bfa594bc408f2e5cfc3de21b533ab62b4f29eb8ca653" auto_tcltk standard
-install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby
+install_package "rubygems-1.6.2" "https://d2chzxaqi4y7f8.cloudfront.net/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p302
+++ b/share/ruby-build/1.8.7-p302
@@ -1,3 +1,3 @@
 require_gcc
 install_package "ruby-1.8.7-p302" "http://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p302.tar.gz#5883df5204de70762602ce885b18c8bf6c856d33298c35df9151031b2ce044a1" auto_tcltk standard
-install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby
+install_package "rubygems-1.6.2" "https://d2chzxaqi4y7f8.cloudfront.net/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p334
+++ b/share/ruby-build/1.8.7-p334
@@ -1,3 +1,3 @@
 require_gcc
 install_package "ruby-1.8.7-p334" "http://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p334.tar.gz#68f68d6480955045661fab3be614c504bfcac167d070c6fdbfc9dbe2c5444bc0" auto_tcltk standard
-install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby
+install_package "rubygems-1.6.2" "https://d2chzxaqi4y7f8.cloudfront.net/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p352
+++ b/share/ruby-build/1.8.7-p352
@@ -1,3 +1,3 @@
 require_gcc
 install_package "ruby-1.8.7-p352" "http://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p352.tar.gz#2325b9f9ab2af663469d057c6a1ef59d914a649808e9f6d1a4877c8973c2dad0" auto_tcltk standard
-install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby
+install_package "rubygems-1.6.2" "https://d2chzxaqi4y7f8.cloudfront.net/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p357
+++ b/share/ruby-build/1.8.7-p357
@@ -1,3 +1,3 @@
 require_gcc
 install_package "ruby-1.8.7-p357" "http://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p357.tar.gz#2fdcac4eb37b2eba1a4eef392a2922e07a9222fc86d781d92154d716434b962c" auto_tcltk standard
-install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby
+install_package "rubygems-1.6.2" "https://d2chzxaqi4y7f8.cloudfront.net/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p358
+++ b/share/ruby-build/1.8.7-p358
@@ -1,3 +1,3 @@
 require_gcc
 install_package "ruby-1.8.7-p358" "http://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p358.tar.gz#9e0856d58830e08f1e38233947d859898ae09d4780cb1a502108e41308de33cb" auto_tcltk standard
-install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby
+install_package "rubygems-1.6.2" "https://d2chzxaqi4y7f8.cloudfront.net/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p370
+++ b/share/ruby-build/1.8.7-p370
@@ -1,3 +1,3 @@
 require_gcc
 install_package "ruby-1.8.7-p370" "http://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p370.tar.gz#bcd8db47adf6f5e3822b60a04785eedb1b97d41fbd7cb595d02759faa36581c6" auto_tcltk standard
-install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby
+install_package "rubygems-1.6.2" "https://d2chzxaqi4y7f8.cloudfront.net/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p371
+++ b/share/ruby-build/1.8.7-p371
@@ -1,3 +1,3 @@
 require_gcc
 install_package "ruby-1.8.7-p371" "http://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p371.tar.gz#e60a322f8f2a616eba01651f5ab620e7e48e4f8adfe711aec61cc74a91d54d3c" auto_tcltk standard
-install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby
+install_package "rubygems-1.6.2" "https://d2chzxaqi4y7f8.cloudfront.net/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p374
+++ b/share/ruby-build/1.8.7-p374
@@ -1,3 +1,3 @@
 require_gcc
 install_package "ruby-1.8.7-p374" "http://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p374.tar.gz#876eeeaaeeab10cbf4767833547d66d86d6717ef48fd3d89e27db8926a65276c" auto_tcltk standard
-install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby
+install_package "rubygems-1.6.2" "https://d2chzxaqi4y7f8.cloudfront.net/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p375
+++ b/share/ruby-build/1.8.7-p375
@@ -1,3 +1,3 @@
 require_gcc
 install_svn "ruby-1.8.7-p375" "http://svn.ruby-lang.org/repos/ruby/branches/ruby_1_8_7" "44351" autoconf auto_tcltk standard
-install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby
+install_package "rubygems-1.6.2" "https://d2chzxaqi4y7f8.cloudfront.net/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.9.1-p378
+++ b/share/ruby-build/1.9.1-p378
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.1-p378" "http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p378.tar.gz#b2960c330aa097c0cf90157a3133c6553ccdf8198e4c717c72cbe87c7f277547"
-install_package "rubygems-1.3.7" "http://production.cf.rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby
+install_package "rubygems-1.3.7" "https://d2chzxaqi4y7f8.cloudfront.net/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.1-p430
+++ b/share/ruby-build/1.9.1-p430
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.1-p430" "http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p430.tar.gz#6d28120e792a4a1cf32dd5f90c1643ecb48760157322a1bb267dd784d14fcb3a"
-install_package "rubygems-1.3.7" "http://production.cf.rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby
+install_package "rubygems-1.3.7" "https://d2chzxaqi4y7f8.cloudfront.net/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.2-p0
+++ b/share/ruby-build/1.9.2-p0
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.2-p0" "http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p0.tar.gz#8c0c4e261a921b5c406bf9e76ac23bf3c915651534e9d1b9e8c5d0bee4a7285c"
-install_package "rubygems-1.8.23" "http://production.cf.rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby
+install_package "rubygems-1.8.23" "https://d2chzxaqi4y7f8.cloudfront.net/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.2-p180
+++ b/share/ruby-build/1.9.2-p180
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.2-p180" "http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p180.tar.gz#9027a5abaaadc2af85005ed74aeb628ce2326441874bf3d4f1a842663cde04f4"
-install_package "rubygems-1.8.23" "http://production.cf.rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby
+install_package "rubygems-1.8.23" "https://d2chzxaqi4y7f8.cloudfront.net/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.2-p290
+++ b/share/ruby-build/1.9.2-p290
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.2-p290" "http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p290.tar.gz#1cc817575c4944d3d78959024320ed1d5b7c2b4931a855772dacad7c3f6ebd7e"
-install_package "rubygems-1.8.23" "http://production.cf.rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby
+install_package "rubygems-1.8.23" "https://d2chzxaqi4y7f8.cloudfront.net/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.2-p318
+++ b/share/ruby-build/1.9.2-p318
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.2-p318" "http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p318.tar.gz#891f707714cb7585ffc76dfaf855e4fcd5b2c0a64655b62d9b23b6a3985a2749"
-install_package "rubygems-1.8.23" "http://production.cf.rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby
+install_package "rubygems-1.8.23" "https://d2chzxaqi4y7f8.cloudfront.net/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.2-p320
+++ b/share/ruby-build/1.9.2-p320
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.2-p320" "http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p320.tar.gz#39a1f046e8756c1885cde42b234bc608196e50feadf1d0f202f7634f4a4b1245"
-install_package "rubygems-1.8.23" "http://production.cf.rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby
+install_package "rubygems-1.8.23" "https://d2chzxaqi4y7f8.cloudfront.net/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.2-p326
+++ b/share/ruby-build/1.9.2-p326
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_svn "ruby-1.9.2-p326" "http://svn.ruby-lang.org/repos/ruby/branches/ruby_1_9_2" "44353" autoconf standard
-install_package "rubygems-1.8.23" "http://production.cf.rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby
+install_package "rubygems-1.8.23" "https://d2chzxaqi4y7f8.cloudfront.net/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.2-p330
+++ b/share/ruby-build/1.9.2-p330
@@ -1,5 +1,5 @@
 require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.2-p330" "http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p330.tar.gz#23ef45fdaecc5d6c7b4e9e2d51b23817fc6aa8225a20f123f7fa98760e8b5ca9"
-install_package "rubygems-1.8.23" "http://production.cf.rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby
+install_package "rubygems-1.8.23" "https://d2chzxaqi4y7f8.cloudfront.net/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby
 

--- a/share/ruby-build/1.9.3-p0
+++ b/share/ruby-build/1.9.3-p0
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p0" "http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p0.tar.gz#3b910042e3561f4296fd95d96bf30322e53eecf083992e5042a7680698cfa34e"
-install_package "rubygems-1.8.23" "http://production.cf.rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby
+install_package "rubygems-1.8.23" "https://d2chzxaqi4y7f8.cloudfront.net/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.3-p125
+++ b/share/ruby-build/1.9.3-p125
@@ -1,4 +1,4 @@
 [ -n "$CC" ] || export CC=cc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p125" "http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p125.tar.gz#8b3c035cf4f0ad6420f447d6a48e8817e5384d0504514939aeb156e251d44cce"
-install_package "rubygems-1.8.23" "http://production.cf.rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby
+install_package "rubygems-1.8.23" "https://d2chzxaqi4y7f8.cloudfront.net/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.3-preview1
+++ b/share/ruby-build/1.9.3-preview1
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-preview1" "http://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-preview1.tar.gz#75c2dd57cabd67d8078a61db4ae86b22dc6f262b84460e5b95a0d8a327b36642"
-install_package "rubygems-1.8.23" "http://production.cf.rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby
+install_package "rubygems-1.8.23" "https://d2chzxaqi4y7f8.cloudfront.net/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/jruby-9.0.0.0-dev
+++ b/share/ruby-build/jruby-9.0.0.0-dev
@@ -1,2 +1,2 @@
 require_java7
-install_package "jruby-9.0.0.0-SNAPSHOT" "http://ci.jruby.org/snapshots/master/jruby-dist-9.0.0.0-SNAPSHOT-bin.tar.gz" jruby
+install_package "jruby-9.0.0.0-SNAPSHOT" "https://s3.amazonaws.com/ci.jruby.org/snapshots/master/jruby-dist-9.0.0.0-SNAPSHOT-bin.tar.gz" jruby

--- a/share/ruby-build/rbx-1.2.4
+++ b/share/ruby-build/rbx-1.2.4
@@ -1,3 +1,3 @@
 require_llvm 2.8
-install_package "rubinius-1.2.4" "http://asset.rubini.us/rubinius-1.2.4-20110705.tar.gz#d474fb6f50292bff5211aaa80b1cead1fb3ed5c7c49223c51fddb8ffc5c3f23d" rbx
-install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby
+install_package "rubinius-1.2.4" "https://s3.amazonaws.com/asset.rubini.us/rubinius-1.2.4-20110705.tar.gz#d474fb6f50292bff5211aaa80b1cead1fb3ed5c7c49223c51fddb8ffc5c3f23d" rbx
+install_package "rubygems-1.6.2" "https://d2chzxaqi4y7f8.cloudfront.net/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/rbx-2.0.0
+++ b/share/ruby-build/rbx-2.0.0
@@ -1,3 +1,3 @@
 require_llvm 3.2
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749"
-install_package "rubinius-2.0.0" "http://releases.rubini.us/rubinius-2.0.0.tar.bz2#df039c7c52e9e42a2f3e0d0b67bf2c9b255769d1f8c3bac2333469ca8c0e04c4" rbx
+install_package "rubinius-2.0.0" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.0.0.tar.bz2#df039c7c52e9e42a2f3e0d0b67bf2c9b255769d1f8c3bac2333469ca8c0e04c4" rbx

--- a/share/ruby-build/rbx-2.1.0
+++ b/share/ruby-build/rbx-2.1.0
@@ -1,3 +1,3 @@
 require_llvm 3.2
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749"
-install_package "rubinius-2.1.0" "http://releases.rubini.us/rubinius-2.1.0.tar.bz2#78d7c2af7ebdf9b477a682cf4793e56e4139abed3cd752282e422d56e63b65b6" rbx
+install_package "rubinius-2.1.0" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.1.0.tar.bz2#78d7c2af7ebdf9b477a682cf4793e56e4139abed3cd752282e422d56e63b65b6" rbx

--- a/share/ruby-build/rbx-2.1.1
+++ b/share/ruby-build/rbx-2.1.1
@@ -1,3 +1,3 @@
 require_llvm 3.2
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749"
-install_package "rubinius-2.1.1" "http://releases.rubini.us/rubinius-2.1.1.tar.bz2#e142c3f201e4ae9f3a6e6671298baabbd9bd906509c663adcf080bff4181ee96" rbx
+install_package "rubinius-2.1.1" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.1.1.tar.bz2#e142c3f201e4ae9f3a6e6671298baabbd9bd906509c663adcf080bff4181ee96" rbx

--- a/share/ruby-build/rbx-2.2.0
+++ b/share/ruby-build/rbx-2.2.0
@@ -1,2 +1,2 @@
 require_llvm 3.2
-install_package "rubinius-2.2.0" "http://releases.rubini.us/rubinius-2.2.0.tar.bz2#50e214b4d2f18d06453b8ef30dfd8268c5e94f8e97ccae877b90457d4c2b9a7e" rbx
+install_package "rubinius-2.2.0" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.2.0.tar.bz2#50e214b4d2f18d06453b8ef30dfd8268c5e94f8e97ccae877b90457d4c2b9a7e" rbx

--- a/share/ruby-build/rbx-2.2.1
+++ b/share/ruby-build/rbx-2.2.1
@@ -1,2 +1,2 @@
 require_llvm 3.2
-install_package "rubinius-2.2.1" "http://releases.rubini.us/rubinius-2.2.1.tar.bz2#2a2a4705cf517470b86b4a8e27e16b11ec363789b690411c792e0f8908c06cb0" rbx
+install_package "rubinius-2.2.1" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.2.1.tar.bz2#2a2a4705cf517470b86b4a8e27e16b11ec363789b690411c792e0f8908c06cb0" rbx

--- a/share/ruby-build/rbx-2.2.10
+++ b/share/ruby-build/rbx-2.2.10
@@ -1,2 +1,2 @@
 require_llvm 3.2
-install_package "rubinius-2.2.10" "http://releases.rubini.us/rubinius-2.2.10.tar.bz2#2a3e6b71f27073b8d83b9592b05523af70bc147ddcd0673bffae55b4167c9d81" rbx
+install_package "rubinius-2.2.10" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.2.10.tar.bz2#3cb1a6ab2eba19b6dc84734666bb17a34332d247641b1a88b4c9324c69347780" rbx

--- a/share/ruby-build/rbx-2.2.2
+++ b/share/ruby-build/rbx-2.2.2
@@ -1,2 +1,2 @@
 require_llvm 3.2
-install_package "rubinius-2.2.2" "http://releases.rubini.us/rubinius-2.2.2.tar.bz2#a49d596f889405e4fc511da64b8afe5eccfafdcee5ea99be15d3ad36290ec2ba" rbx
+install_package "rubinius-2.2.2" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.2.2.tar.bz2#a49d596f889405e4fc511da64b8afe5eccfafdcee5ea99be15d3ad36290ec2ba" rbx

--- a/share/ruby-build/rbx-2.2.3
+++ b/share/ruby-build/rbx-2.2.3
@@ -1,2 +1,2 @@
 require_llvm 3.2
-install_package "rubinius-2.2.3" "http://releases.rubini.us/rubinius-2.2.3.tar.bz2#b3426aa6996420f1d9d8a7926a94160b84d8bdf725793c64462b27b74f2f2acf" rbx
+install_package "rubinius-2.2.3" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.2.3.tar.bz2#b3426aa6996420f1d9d8a7926a94160b84d8bdf725793c64462b27b74f2f2acf" rbx

--- a/share/ruby-build/rbx-2.2.4
+++ b/share/ruby-build/rbx-2.2.4
@@ -1,2 +1,2 @@
 require_llvm 3.2
-install_package "rubinius-2.2.4" "http://releases.rubini.us/rubinius-2.2.4.tar.bz2#7d06d63d12d9eecff196d8f53953bd520c17fbb9baa921c5481c43af8129d85e" rbx
+install_package "rubinius-2.2.4" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.2.4.tar.bz2#7d06d63d12d9eecff196d8f53953bd520c17fbb9baa921c5481c43af8129d85e" rbx

--- a/share/ruby-build/rbx-2.2.5
+++ b/share/ruby-build/rbx-2.2.5
@@ -1,2 +1,2 @@
 require_llvm 3.2
-install_package "rubinius-2.2.5" "http://releases.rubini.us/rubinius-2.2.5.tar.bz2#42cfae89d481dfa5e0ccb53a67720f109fc6c2e1b6ca68a8ae9676be6d0457de" rbx
+install_package "rubinius-2.2.5" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.2.5.tar.bz2#42cfae89d481dfa5e0ccb53a67720f109fc6c2e1b6ca68a8ae9676be6d0457de" rbx

--- a/share/ruby-build/rbx-2.2.6
+++ b/share/ruby-build/rbx-2.2.6
@@ -1,2 +1,2 @@
 require_llvm 3.2
-install_package "rubinius-2.2.6" "http://releases.rubini.us/rubinius-2.2.6.tar.bz2#8ad2cada05a20c708379c75607fd0c8259623b3699d36be41e509052164eb103" rbx
+install_package "rubinius-2.2.6" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.2.6.tar.bz2#8ad2cada05a20c708379c75607fd0c8259623b3699d36be41e509052164eb103" rbx

--- a/share/ruby-build/rbx-2.2.7
+++ b/share/ruby-build/rbx-2.2.7
@@ -1,2 +1,2 @@
 require_llvm 3.2
-install_package "rubinius-2.2.7" "http://releases.rubini.us/rubinius-2.2.7.tar.bz2#e1244b60ed790a3a33a7126a587c35acd041dcb2022b894833518490e872dc3d" rbx
+install_package "rubinius-2.2.7" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.2.7.tar.bz2#e1244b60ed790a3a33a7126a587c35acd041dcb2022b894833518490e872dc3d" rbx

--- a/share/ruby-build/rbx-2.2.9
+++ b/share/ruby-build/rbx-2.2.9
@@ -1,2 +1,2 @@
 require_llvm 3.2
-install_package "rubinius-2.2.9" "http://releases.rubini.us/rubinius-2.2.9.tar.bz2#7b01a7f2508167e73b5273b4e55e6616fc7fd975e79c84c4d2e3ef83d849d2ce" rbx
+install_package "rubinius-2.2.9" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.2.9.tar.bz2#7b01a7f2508167e73b5273b4e55e6616fc7fd975e79c84c4d2e3ef83d849d2ce" rbx

--- a/share/ruby-build/rbx-2.3.0
+++ b/share/ruby-build/rbx-2.3.0
@@ -1,2 +1,2 @@
 require_llvm 3.5
-install_package "rubinius-2.3.0" "http://releases.rubini.us/rubinius-2.3.0.tar.bz2#9953c3af5e9694540859eaf55164a38d0c32c3ad35457e4351d20c28a25fecaa" rbx
+install_package "rubinius-2.3.0" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.3.0.tar.bz2#9953c3af5e9694540859eaf55164a38d0c32c3ad35457e4351d20c28a25fecaa" rbx

--- a/share/ruby-build/rbx-2.4.0
+++ b/share/ruby-build/rbx-2.4.0
@@ -1,2 +1,2 @@
 require_llvm 3.5
-install_package "rubinius-2.4.0" "http://releases.rubini.us/rubinius-2.4.0.tar.bz2#89390e8dd890ac4b8ad931e6277714e3d55560ee2f236b756bb4f83ee26eb9b0" rbx
+install_package "rubinius-2.4.0" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.4.0.tar.bz2#89390e8dd890ac4b8ad931e6277714e3d55560ee2f236b756bb4f83ee26eb9b0" rbx

--- a/share/ruby-build/rbx-2.4.1
+++ b/share/ruby-build/rbx-2.4.1
@@ -1,2 +1,2 @@
 require_llvm 3.5
-install_package "rubinius-2.4.1" "http://releases.rubini.us/rubinius-2.4.1.tar.bz2#a5967afe9f9305c08f97a22dd210922c33be79b293fc346f617ff31f280f136e" rbx
+install_package "rubinius-2.4.1" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.4.1.tar.bz2#a5967afe9f9305c08f97a22dd210922c33be79b293fc346f617ff31f280f136e" rbx

--- a/share/ruby-build/rbx-2.5.0
+++ b/share/ruby-build/rbx-2.5.0
@@ -1,2 +1,2 @@
 require_llvm 3.5
-install_package "rubinius-2.5.0" "http://releases.rubini.us/rubinius-2.5.0.tar.bz2#9f14a47080e8f175afb94f6e600812115185c91f2e081f976262aea7804e4ceb" rbx
+install_package "rubinius-2.5.0" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.5.0.tar.bz2#9f14a47080e8f175afb94f6e600812115185c91f2e081f976262aea7804e4ceb" rbx

--- a/share/ruby-build/rbx-2.5.1
+++ b/share/ruby-build/rbx-2.5.1
@@ -1,2 +1,2 @@
 require_llvm 3.5
-install_package "rubinius-2.5.1" "http://releases.rubini.us/rubinius-2.5.1.tar.bz2#00d6f23b7632d035d322209e736a9341155350a9d169e8471d38a554a8e26600" rbx
+install_package "rubinius-2.5.1" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.5.1.tar.bz2#00d6f23b7632d035d322209e736a9341155350a9d169e8471d38a554a8e26600" rbx

--- a/share/ruby-build/rbx-2.5.2
+++ b/share/ruby-build/rbx-2.5.2
@@ -1,2 +1,2 @@
 require_llvm 3.5
-install_package "rubinius-2.5.2" "http://releases.rubini.us/rubinius-2.5.2.tar.bz2#1b077537224d4ff1f8c628e5bbe0621dc6f833bc2d67a03aa10173b72299a1a8" rbx
+install_package "rubinius-2.5.2" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.5.2.tar.bz2#1b077537224d4ff1f8c628e5bbe0621dc6f833bc2d67a03aa10173b72299a1a8" rbx

--- a/share/ruby-build/ree-1.8.6-2009.06
+++ b/share/ruby-build/ree-1.8.6-2009.06
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-enterprise-1.8.6-20090610" "http://files.rubyforge.vm.bytemark.co.uk/emm-ruby/ruby-enterprise-1.8.6-20090610.tar.gz#8bfb592b22f8d5131c0ea3a54769c75a5b2fba88ba9244a1bc8c0442fa7df417" ree_installer
-install_package "rubygems-1.4.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.4.2.tgz#85da41916deff8883a75710d69d43727a36b4573dd099600f9ff4032700ba5c0" ruby
+install_package "ruby-enterprise-1.8.6-20090610" "http://mirror.as24220.net/pub/rubygems/files/emm-ruby/ruby-enterprise-1.8.6-20090610.tar.gz#8bfb592b22f8d5131c0ea3a54769c75a5b2fba88ba9244a1bc8c0442fa7df417" ree_installer
+install_package "rubygems-1.4.2" "https://d2chzxaqi4y7f8.cloudfront.net/rubygems/rubygems-1.4.2.tgz#85da41916deff8883a75710d69d43727a36b4573dd099600f9ff4032700ba5c0" ruby

--- a/share/ruby-build/ree-1.8.7-2009.09
+++ b/share/ruby-build/ree-1.8.7-2009.09
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-enterprise-1.8.7-20090928" "http://files.rubyforge.vm.bytemark.co.uk/emm-ruby/ruby-enterprise-1.8.7-20090928.tar.gz#57299d73a65b527b6a849f89bdb92e3608f8cb3af77801ae6716a661857d7605" ree_installer
-install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby
+install_package "ruby-enterprise-1.8.7-20090928" "http://mirror.as24220.net/pub/rubygems/files/emm-ruby/ruby-enterprise-1.8.7-20090928.tar.gz#57299d73a65b527b6a849f89bdb92e3608f8cb3af77801ae6716a661857d7605" ree_installer
+install_package "rubygems-1.6.2" "https://d2chzxaqi4y7f8.cloudfront.net/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/ree-1.8.7-2009.10
+++ b/share/ruby-build/ree-1.8.7-2009.10
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-enterprise-1.8.7-2009.10" "http://files.rubyforge.vm.bytemark.co.uk/emm-ruby/ruby-enterprise-1.8.7-2009.10.tar.gz#d4f280adf03b59bdb5c8c690f1c322c0d2aa0a7c16797928d759a4d8885333a3" ree_installer
-install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby
+install_package "ruby-enterprise-1.8.7-2009.10" "http://mirror.as24220.net/pub/rubygems/files/emm-ruby/ruby-enterprise-1.8.7-2009.10.tar.gz#d4f280adf03b59bdb5c8c690f1c322c0d2aa0a7c16797928d759a4d8885333a3" ree_installer
+install_package "rubygems-1.6.2" "https://d2chzxaqi4y7f8.cloudfront.net/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/ree-1.8.7-2010.01
+++ b/share/ruby-build/ree-1.8.7-2010.01
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-enterprise-1.8.7-2010.01" "http://files.rubyforge.vm.bytemark.co.uk/emm-ruby/ruby-enterprise-1.8.7-2010.01.tar.gz#ccdf836693ea9c110bf8b97ced91be3db100487428a6668d0b45fb883fa6793d" ree_installer
-install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby
+install_package "ruby-enterprise-1.8.7-2010.01" "http://mirror.as24220.net/pub/rubygems/files/emm-ruby/ruby-enterprise-1.8.7-2010.01.tar.gz#ccdf836693ea9c110bf8b97ced91be3db100487428a6668d0b45fb883fa6793d" ree_installer
+install_package "rubygems-1.6.2" "https://d2chzxaqi4y7f8.cloudfront.net/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/ree-1.8.7-2010.02
+++ b/share/ruby-build/ree-1.8.7-2010.02
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-enterprise-1.8.7-2010.02" "http://files.rubyforge.vm.bytemark.co.uk/emm-ruby/ruby-enterprise-1.8.7-2010.02.tar.gz#5e7268021aa30f9b79f3ed066989cffc8b31b17db9e2aca40c039ff017da4813" ree_installer
-install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby
+install_package "ruby-enterprise-1.8.7-2010.02" "http://mirror.as24220.net/pub/rubygems/files/emm-ruby/ruby-enterprise-1.8.7-2010.02.tar.gz#5e7268021aa30f9b79f3ed066989cffc8b31b17db9e2aca40c039ff017da4813" ree_installer
+install_package "rubygems-1.6.2" "https://d2chzxaqi4y7f8.cloudfront.net/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/ree-1.8.7-2011.03
+++ b/share/ruby-build/ree-1.8.7-2011.03
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-enterprise-1.8.7-2011.03" "http://rubyenterpriseedition.googlecode.com/files/ruby-enterprise-1.8.7-2011.03.tar.gz#0c0ddbc43b3aef49686db27e761e55a23437f12e1f00b6fe55d94724637bff6b" ree_installer
-install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby
+install_package "ruby-enterprise-1.8.7-2011.03" "https://rubyenterpriseedition.googlecode.com/files/ruby-enterprise-1.8.7-2011.03.tar.gz#0c0ddbc43b3aef49686db27e761e55a23437f12e1f00b6fe55d94724637bff6b" ree_installer
+install_package "rubygems-1.6.2" "https://d2chzxaqi4y7f8.cloudfront.net/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/ree-1.8.7-2011.12
+++ b/share/ruby-build/ree-1.8.7-2011.12
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-enterprise-1.8.7-2011.12" "http://rubyenterpriseedition.googlecode.com/files/ruby-enterprise-1.8.7-2011.12.tar.gz#9a8efc4befc136e17a1360de549aac9e79283c7238a13215350720e4393c5da2" ree_installer
-install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby
+install_package "ruby-enterprise-1.8.7-2011.12" "https://rubyenterpriseedition.googlecode.com/files/ruby-enterprise-1.8.7-2011.12.tar.gz#9a8efc4befc136e17a1360de549aac9e79283c7238a13215350720e4393c5da2" ree_installer
+install_package "rubygems-1.6.2" "https://d2chzxaqi4y7f8.cloudfront.net/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/ree-1.8.7-2012.01
+++ b/share/ruby-build/ree-1.8.7-2012.01
@@ -1,3 +1,3 @@
 require_gcc
-install_package "ruby-enterprise-1.8.7-2012.01" "http://rubyenterpriseedition.googlecode.com/files/ruby-enterprise-1.8.7-2012.01.tar.gz#c0c4779fc473fc9843c0008acfbae2e2bdf3472b454c7fe6ff0ac4139a691e65" ree_installer
-install_package "rubygems-1.6.2" "http://production.cf.rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby
+install_package "ruby-enterprise-1.8.7-2012.01" "https://rubyenterpriseedition.googlecode.com/files/ruby-enterprise-1.8.7-2012.01.tar.gz#c0c4779fc473fc9843c0008acfbae2e2bdf3472b454c7fe6ff0ac4139a691e65" ree_installer
+install_package "rubygems-1.6.2" "https://d2chzxaqi4y7f8.cloudfront.net/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/ree-1.8.7-2012.02
+++ b/share/ruby-build/ree-1.8.7-2012.02
@@ -1,2 +1,2 @@
 require_gcc
-install_package "ruby-enterprise-1.8.7-2012.02" "http://rubyenterpriseedition.googlecode.com/files/ruby-enterprise-1.8.7-2012.02.tar.gz#ecf4a6d4c96b547b3bf4b6be14e082ddaa781e83ad7f69437cd3169fb7576e42" ree_installer
+install_package "ruby-enterprise-1.8.7-2012.02" "https://rubyenterpriseedition.googlecode.com/files/ruby-enterprise-1.8.7-2012.02.tar.gz#ecf4a6d4c96b547b3bf4b6be14e082ddaa781e83ad7f69437cd3169fb7576e42" ree_installer

--- a/test/arguments.bats
+++ b/test/arguments.bats
@@ -2,7 +2,7 @@
 
 load test_helper
 
-@test "not enought arguments for ruby-build" {
+@test "not enough arguments for ruby-build" {
   # use empty inline definition so nothing gets built anyway
   local definition="${TMP}/build-definition"
   echo '' > "$definition"

--- a/test/build.bats
+++ b/test/build.bats
@@ -164,7 +164,7 @@ OUT
   stub_make_install
 
   run_inline_definition <<DEF
-install_package "ruby-2.0.0" "http://ruby-lang.org/ruby/2.0/ruby-2.0.0.tar.gz"
+install_package "ruby-2.0.0" "https://www.ruby-lang.org/ruby/2.0/ruby-2.0.0.tar.gz"
 DEF
   assert_success
 
@@ -186,7 +186,7 @@ OUT
 
   export RUBY_CONFIGURE_OPTS='--with-readline-dir=/custom'
   run_inline_definition <<DEF
-install_package "ruby-2.0.0" "http://ruby-lang.org/ruby/2.0/ruby-2.0.0.tar.gz"
+install_package "ruby-2.0.0" "https://www.ruby-lang.org/ruby/2.0/ruby-2.0.0.tar.gz"
 DEF
   assert_success
 
@@ -209,7 +209,7 @@ OUT
 
   export -n MAKE_OPTS
   run_inline_definition <<DEF
-install_package "ruby-2.0.0" "http://ruby-lang.org/ruby/2.0/ruby-2.0.0.tar.gz"
+install_package "ruby-2.0.0" "https://www.ruby-lang.org/ruby/2.0/ruby-2.0.0.tar.gz"
 DEF
   assert_success
 
@@ -232,7 +232,7 @@ OUT
 
   export -n MAKE_OPTS
   run_inline_definition <<DEF
-install_package "ruby-2.0.0" "http://ruby-lang.org/ruby/2.0/ruby-2.0.0.tar.gz"
+install_package "ruby-2.0.0" "https://www.ruby-lang.org/ruby/2.0/ruby-2.0.0.tar.gz"
 DEF
   assert_success
 
@@ -256,7 +256,7 @@ OUT
 
   export -n MAKE_OPTS
   run_inline_definition <<DEF
-install_package "ruby-2.0.0" "http://ruby-lang.org/ruby/2.0/ruby-2.0.0.tar.gz"
+install_package "ruby-2.0.0" "https://www.ruby-lang.org/ruby/2.0/ruby-2.0.0.tar.gz"
 DEF
   assert_success
 
@@ -278,7 +278,7 @@ OUT
 
   export RUBY_MAKE_INSTALL_OPTS="DOGE=\"such wow\""
   run_inline_definition <<DEF
-install_package "ruby-2.0.0" "http://ruby-lang.org/ruby/2.0/ruby-2.0.0.tar.gz"
+install_package "ruby-2.0.0" "https://www.ruby-lang.org/ruby/2.0/ruby-2.0.0.tar.gz"
 DEF
   assert_success
 
@@ -298,7 +298,7 @@ OUT
 
   export MAKE_INSTALL_OPTS="DOGE=\"such wow\""
   run_inline_definition <<DEF
-install_package "ruby-2.0.0" "http://ruby-lang.org/ruby/2.0/ruby-2.0.0.tar.gz"
+install_package "ruby-2.0.0" "https://www.ruby-lang.org/ruby/2.0/ruby-2.0.0.tar.gz"
 DEF
   assert_success
 
@@ -359,7 +359,7 @@ CONF
 
   export RUBY_CONFIGURE="${TMP}/custom-configure"
   run_inline_definition <<DEF
-install_package "ruby-2.0.0" "http://ruby-lang.org/pub/ruby-2.0.0.tar.gz"
+install_package "ruby-2.0.0" "https://www.ruby-lang.org/pub/ruby-2.0.0.tar.gz"
 DEF
   assert_success
 
@@ -399,7 +399,7 @@ OUT
   stub rake '--version : echo 1' true
 
   run_inline_definition <<DEF
-install_package "mruby-1.0" "http://ruby-lang.org/pub/mruby-1.0.tar.gz" mruby
+install_package "mruby-1.0" "https://www.ruby-lang.org/pub/mruby-1.0.tar.gz" mruby
 DEF
   assert_success
 
@@ -417,7 +417,7 @@ DEF
   stub gem 'install rake -v *10.1.0 : true'
 
   run_inline_definition <<DEF
-install_package "mruby-1.0" "http://ruby-lang.org/pub/mruby-1.0.tar.gz" mruby
+install_package "mruby-1.0" "https://www.ruby-lang.org/pub/mruby-1.0.tar.gz" mruby
 DEF
   assert_success
 
@@ -437,7 +437,7 @@ DEF
     " exec rake install : { cat build.log; echo bundle \"\$@\"; } >> '$INSTALL_ROOT/build.log'"
 
   run_inline_definition <<DEF
-install_package "rubinius-2.0.0" "http://releases.rubini.us/rubinius-2.0.0.tar.gz" rbx
+install_package "rubinius-2.0.0" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.0.0.tar.gz" rbx
 DEF
   assert_success
 
@@ -467,7 +467,7 @@ OUT
     "install : mkdir -p '$INSTALL_ROOT'; cp -fR . '$INSTALL_ROOT'"
 
   run_inline_definition <<DEF
-install_package "rubinius-2.0.0" "http://releases.rubini.us/rubinius-2.0.0.tar.gz" rbx
+install_package "rubinius-2.0.0" "https://s3.amazonaws.com/releases.rubini.us/rubinius-2.0.0.tar.gz" rbx
 DEF
   assert_success
 
@@ -510,7 +510,7 @@ OUT
   cached_tarball "jruby-1.7.9" bin/foo.exe bin/bar.dll bin/baz.bat
 
   run_inline_definition <<DEF
-install_package "jruby-1.7.9" "http://jruby.org/downloads/jruby-bin-1.7.9.tar.gz" jruby
+install_package "jruby-1.7.9" "https://s3.amazonaws.com/jruby.org/downloads/1.7.9/jruby-bin-1.7.9.tar.gz" jruby
 DEF
   assert_success
 
@@ -556,7 +556,7 @@ DEF
 
   run_inline_definition <<DEF
 require_java7
-install_package "jruby-9000.dev" "http://ci.jruby.org/jruby-dist-9000.dev-bin.tar.gz" jruby
+install_package "jruby-9000.dev" "https://s3.amazonaws.com/ci.jruby.org/jruby-dist-9000.dev-bin.tar.gz" jruby
 DEF
   assert_failure
   assert_output_contains "ERROR: Java 7 required. Please install a 1.7-compatible JRE."
@@ -569,7 +569,7 @@ DEF
 
   run_inline_definition <<DEF
 require_java7
-install_package "jruby-9000.dev" "http://ci.jruby.org/jruby-dist-9000.dev-bin.tar.gz" jruby
+install_package "jruby-9000.dev" "https://s3.amazonaws.com/ci.jruby.org/jruby-dist-9000.dev-bin.tar.gz" jruby
 DEF
   assert_failure
   assert_output_contains "ERROR: Java 7 required. Please install a 1.7-compatible JRE."
@@ -582,7 +582,7 @@ DEF
 
   run_inline_definition <<DEF
 require_java7
-install_package "jruby-9000.dev" "http://ci.jruby.org/jruby-dist-9000.dev-bin.tar.gz" jruby
+install_package "jruby-9000.dev" "https://s3.amazonaws.com/ci.jruby.org/jruby-dist-9000.dev-bin.tar.gz" jruby
 DEF
   assert_success
 }
@@ -594,7 +594,7 @@ DEF
 
   run_inline_definition <<DEF
 require_java7
-install_package "jruby-9000.dev" "http://ci.jruby.org/jruby-dist-9000.dev-bin.tar.gz" jruby
+install_package "jruby-9000.dev" "https://s3.amazonaws.com/ci.jruby.org/jruby-dist-9000.dev-bin.tar.gz" jruby
 DEF
   assert_success
 }

--- a/test/cache.bats
+++ b/test/cache.bats
@@ -59,7 +59,7 @@ setup() {
 
   stub shasum true "echo invalid" "echo $checksum"
   stub curl "-*I* : true" \
-    "-q -o * -*S* http://?*/$checksum : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3"
+    "-q -o * -*S* https://?*/$checksum : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3"
 
   touch "${RUBY_BUILD_CACHE_PATH}/package-1.0.0.tar.gz"
 

--- a/test/fixtures/definitions/needs-yaml
+++ b/test/fixtures/definitions/needs-yaml
@@ -1,2 +1,2 @@
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz" --if needs_yaml
-install_package "ruby-2.0.0" "http://ruby-lang.org/ruby/2.0/ruby-2.0.0.tar.gz"
+install_package "ruby-2.0.0" "https://www.ruby-lang.org/ruby/2.0/ruby-2.0.0.tar.gz"

--- a/test/fixtures/definitions/vanilla-ruby
+++ b/test/fixtures/definitions/vanilla-ruby
@@ -1,1 +1,1 @@
-install_package "ruby-2.0.0" "http://ruby-lang.org/ruby/2.0/ruby-2.0.0.tar.gz"
+install_package "ruby-2.0.0" "https://www.ruby-lang.org/ruby/2.0/ruby-2.0.0.tar.gz"

--- a/test/mirror.bats
+++ b/test/mirror.bats
@@ -92,7 +92,7 @@ export RUBY_BUILD_MIRROR_URL=http://mirror.example.com
 
   stub shasum true "echo $checksum"
   stub curl "-*I* : true" \
-    "-q -o * -*S* http://?*/$checksum : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3" \
+    "-q -o * -*S* https://?*/$checksum : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3" \
 
   install_fixture definitions/with-checksum
   [ "$status" -eq 0 ]


### PR DESCRIPTION
Even though ruby-build uses hardcoded checksums to help prevent MITM and corruption issues, using SSL/TLS to download the files adds another layer of protection, ensuring that nobody can see that somebody is downloading a certain ruby version.

Quoting Eric Mill from https://bugs.ruby-lang.org/issues/10672

> Even when clients do perform client-side integrity checking, there is always a privacy implication to downloading information. Downloading Ruby without SSL leaks information about the client performing the download through request headers, and informs anyone watching the connection what version of Ruby is likely to be running on the downloading machine. In addition, traffic can be correlated in unpredictable ways: for example, a user agent sent to connect to a download of a Ruby build may appear later to download other information, providing a pattern of client behavior.
> 
> In any case, the web is, in general, moving to favor encrypted connections. SSL is faster, CAs like SSLMate and Let's Encrypt are emerging to make the process simpler, and web browsers are starting to encourage encrypted connections and discourage unencrypted ones.