### PR TITLE
Properly detect OpenJDK versions in bin/ruby-build

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -701,7 +701,7 @@ fix_rbx_irb() {
 }
 
 require_java7() {
-  local version="$(java -version 2>&1 | grep 'java version' | head -1)"
+  local version="$(java -version 2>&1 | grep '\(java\|openjdk\) version' | head -1)"
   if [[ $version != *1.[789]* ]]; then
     colorize 1 "ERROR" >&3
     echo ": Java 7 required. Please install a 1.7-compatible JRE." >&3

--- a/test/build.bats
+++ b/test/build.bats
@@ -599,6 +599,18 @@ DEF
   assert_success
 }
 
+@test "Java version string on OpenJDK" {
+  cached_tarball "jruby-9000.dev" bin/jruby
+
+  stub java "-version : echo 'openjdk version \"1.8.0_40\"' >&2"
+
+  run_inline_definition <<DEF
+require_java7
+install_package "jruby-9000.dev" "http://ci.jruby.org/jruby-dist-9000.dev-bin.tar.gz" jruby
+DEF
+  assert_success
+}
+
 @test "non-writable TMPDIR aborts build" {
   export TMPDIR="${TMP}/build"
   mkdir -p "$TMPDIR"


### PR DESCRIPTION
OpenJDK reports its version slightly different than Oracle Java, and
this was causing the logic in bin/ruby-build to not detect Java 7 or
higher when OpenJDK was used.