### PR TITLE
Fix: Detect LLVM 3.5 installed from Homebrew

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -815,8 +815,8 @@ require_llvm() {
       if [ "$llvm_version" = "3.2" ]; then
         package_option ruby configure --prebuilt-name="llvm-3.2-x86_64-apple-darwin13.tar.bz2"
       else
-        local llvm_prefix="$(brew --prefix llvm 2>/dev/null || true)"
-        local llvm_config="${llvm_prefix}/bin/llvm-config"
+        local llvm_prefix="$(brew --prefix llvm35 2>/dev/null || true)"
+        local llvm_config="${llvm_prefix}/bin/llvm-config-3.5"
         if [ -x "$llvm_config" ]; then
           package_option ruby configure --llvm-config="$llvm_config"
         else
@@ -828,7 +828,7 @@ require_llvm() {
             colorize 1 "TO FIX THE PROBLEM"
             echo ": Install Homebrew's llvm package with this"
             echo -n "command: "
-            colorize 4 "brew install llvm"
+            colorize 4 "brew tap homebrew/versions ; brew install llvm35"
             echo
           } >&3
           return 1

--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -815,8 +815,15 @@ require_llvm() {
       if [ "$llvm_version" = "3.2" ]; then
         package_option ruby configure --prebuilt-name="llvm-3.2-x86_64-apple-darwin13.tar.bz2"
       else
-        local llvm_prefix="$(brew --prefix llvm35 2>/dev/null || true)"
-        local llvm_config="${llvm_prefix}/bin/llvm-config-3.5"
+        local llvm_short_vers="$(echo $llvm_version | cut -d. -f1-2)"
+        local llvm_prefix="$(brew --prefix llvm${llvm_short_vers/./} 2>/dev/null || true)"
+
+        if [ -d "$llvm_prefix" ]; then
+          local llvm_config="${llvm_prefix}/bin/llvm-config-${llvm_short_vers}"
+        else
+          local llvm_config="$(brew --prefix llvm 2>/dev/null || true)/bin/llvm-config"
+        fi
+
         if [ -x "$llvm_config" ]; then
           package_option ruby configure --llvm-config="$llvm_config"
         else


### PR DESCRIPTION
- Updates the command used to detect LLVM 3.5 installed with Homebrew on Mac OS X.
- Updates instructions with current command to install LLVM 3.5 using Homebrew.
- Falls back to existing behavior if version-specific `llvm-config` isn't found.

Around two weeks ago, [Homebrew bumped the version](https://github.com/Homebrew/homebrew/commit/0196a069a01e455b61778d804ebb81f46e7c31ff) of you get with `brew install llvm` from LLVM 3.5.1 to 3.6.0.

So now users will have to tap homebrew-versions and run `brew install llvm35` in order to get the version necessary to install recent versions of Rubinius. The 3.5-specific `llvm-config` becomes `llvm-config-3.5` accordingly.

For users who installed LLVM before Homebrew bumped the version (i.e. their `llvm-config` points to 3.5), we fallback to the existing behavior if the version-specific formula isn't found.
