### PR TITLE
remove sed fallback for help/usage

### DIFF
--- a/bin/rbenv-install
+++ b/bin/rbenv-install
@@ -46,8 +46,7 @@ fi
 eval "$(ruby-build --lib)"
 
 usage() {
-  # We can remove the sed fallback once rbenv 0.4.0 is widely available.
-  rbenv-help install 2>/dev/null || sed -ne '/^#/!q;s/.//;s/.//;1,4d;p' < "$0"
+  rbenv-help install 2>/dev/null
   [ -z "$1" ] || exit "$1"
 }
 

--- a/bin/rbenv-uninstall
+++ b/bin/rbenv-uninstall
@@ -18,8 +18,7 @@ if [ "$1" = "--complete" ]; then
 fi
 
 usage() {
-  # We can remove the sed fallback once rbenv 0.4.0 is widely available.
-  rbenv-help uninstall 2>/dev/null || sed -ne '/^#/!q;s/.//;s/.//;1,4d;p' < "$0"
+  rbenv-help uninstall 2>/dev/null
   [ -z "$1" ] || exit "$1"
 }
 

--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -13,7 +13,7 @@ stub_ruby_build() {
 }
 
 extract_usage_from() {
-  local program="../bin/$1"
+  local program="$BATS_TEST_DIRNAME/../bin/$1"
   sed -ne '/^#/!q;s/.//;s/.//;1,4d;p' < "$program"
 }
 

--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -12,11 +12,6 @@ stub_ruby_build() {
   stub ruby-build "--lib : $BATS_TEST_DIRNAME/../bin/ruby-build --lib" "$@"
 }
 
-extract_usage_from() {
-  local program="$BATS_TEST_DIRNAME/../bin/$1"
-  sed -ne '/^#/!q;s/.//;s/.//;1,4d;p' < "$program"
-}
-
 @test "install proper" {
   stub_ruby_build 'echo ruby-build "$@"'
 
@@ -180,7 +175,7 @@ OUT
 }
 
 @test "rbenv-install has usage help preface" {
-  run extract_usage_from rbenv-install
+  run head "$(which rbenv-install)"
   assert_output_contains 'Usage: rbenv install'
 }
 
@@ -209,6 +204,6 @@ OUT
 }
 
 @test "rbenv-uninstall has usage help preface" {
-  run extract_usage_from rbenv-uninstall
+  run head "$(which rbenv-uninstall)"
   assert_output_contains 'Usage: rbenv uninstall'
 }

--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -158,8 +158,6 @@ OUT
 
   run rbenv-install
   assert_failure
-  assert_output_contains 'Usage: rbenv install'
-
   unstub rbenv-help
 }
 
@@ -169,8 +167,6 @@ OUT
 
   run rbenv-install 2.1.1 2.1.2
   assert_failure
-  assert_output_contains 'Usage: rbenv install'
-
   unstub rbenv-help
 }
 
@@ -180,8 +176,6 @@ OUT
 
   run rbenv-install -h
   assert_success
-  assert_output_contains 'Usage: rbenv install'
-
   unstub rbenv-help
 }
 
@@ -195,8 +189,6 @@ OUT
 
   run rbenv-uninstall
   assert_failure
-  assert_output_contains 'Usage: rbenv uninstall'
-
   unstub rbenv-help
 }
 
@@ -205,8 +197,6 @@ OUT
 
   run rbenv-uninstall 2.1.1 2.1.2
   assert_failure
-  assert_output_contains 'Usage: rbenv uninstall'
-
   unstub rbenv-help
 }
 
@@ -215,8 +205,6 @@ OUT
 
   run rbenv-uninstall -h
   assert_success
-  assert_output_contains 'Usage: rbenv uninstall'
-
   unstub rbenv-help
 }
 

--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -149,7 +149,7 @@ OUT
 
 @test "not enough arguments for rbenv-install" {
   stub_ruby_build
-  stub rbenv-help 'echo "Usage: rbenv install"'
+  stub rbenv-help 'install : echo "Usage: rbenv install"'
 
   run rbenv-install
   assert_failure
@@ -160,7 +160,7 @@ OUT
 
 @test "too many arguments for rbenv-install" {
   stub_ruby_build
-  stub rbenv-help 'echo "Usage: rbenv install"'
+  stub rbenv-help 'install : echo "Usage: rbenv install"'
 
   run rbenv-install 2.1.1 2.1.2
   assert_failure
@@ -171,7 +171,7 @@ OUT
 
 @test "show help for rbenv-install" {
   stub_ruby_build
-  stub rbenv-help 'echo "Usage: rbenv install"'
+  stub rbenv-help 'install : echo "Usage: rbenv install"'
 
   run rbenv-install -h
   assert_success
@@ -181,7 +181,7 @@ OUT
 }
 
 @test "not enough arguments rbenv-uninstall" {
-  stub rbenv-help 'echo "Usage: rbenv uninstall"'
+  stub rbenv-help 'uninstall : echo "Usage: rbenv uninstall"'
 
   run rbenv-uninstall
   assert_failure
@@ -191,7 +191,7 @@ OUT
 }
 
 @test "too many arguments for rbenv-uninstall" {
-  stub rbenv-help 'echo "Usage: rbenv uninstall"'
+  stub rbenv-help 'uninstall : echo "Usage: rbenv uninstall"'
 
   run rbenv-uninstall 2.1.1 2.1.2
   assert_failure
@@ -201,7 +201,7 @@ OUT
 }
 
 @test "show help for rbenv-uninstall" {
-  stub rbenv-help 'echo "Usage: rbenv uninstall"'
+  stub rbenv-help 'uninstall : echo "Usage: rbenv uninstall"'
 
   run rbenv-uninstall -h
   assert_success

--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -12,6 +12,11 @@ stub_ruby_build() {
   stub ruby-build "--lib : $BATS_TEST_DIRNAME/../bin/ruby-build --lib" "$@"
 }
 
+extract_usage_from() {
+  local program="../bin/$1"
+  sed -ne '/^#/!q;s/.//;s/.//;1,4d;p' < "$program"
+}
+
 @test "install proper" {
   stub_ruby_build 'echo ruby-build "$@"'
 
@@ -180,6 +185,11 @@ OUT
   unstub rbenv-help
 }
 
+@test "rbenv-install has usage help preface" {
+  run extract_usage_from rbenv-install
+  assert_output_contains 'Usage: rbenv install'
+}
+
 @test "not enough arguments rbenv-uninstall" {
   stub rbenv-help 'uninstall : echo "Usage: rbenv uninstall"'
 
@@ -208,4 +218,9 @@ OUT
   assert_output_contains 'Usage: rbenv uninstall'
 
   unstub rbenv-help
+}
+
+@test "rbenv-uninstall has usage help preface" {
+  run extract_usage_from rbenv-uninstall
+  assert_output_contains 'Usage: rbenv uninstall'
 }

--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -149,39 +149,63 @@ OUT
 
 @test "not enough arguments for rbenv-install" {
   stub_ruby_build
+  stub rbenv-help 'echo "Usage: rbenv install"'
+
   run rbenv-install
   assert_failure
   assert_output_contains 'Usage: rbenv install'
+
+  unstub rbenv-help
 }
 
 @test "too many arguments for rbenv-install" {
   stub_ruby_build
+  stub rbenv-help 'echo "Usage: rbenv install"'
+
   run rbenv-install 2.1.1 2.1.2
   assert_failure
   assert_output_contains 'Usage: rbenv install'
+
+  unstub rbenv-help
 }
 
 @test "show help for rbenv-install" {
   stub_ruby_build
+  stub rbenv-help 'echo "Usage: rbenv install"'
+
   run rbenv-install -h
   assert_success
   assert_output_contains 'Usage: rbenv install'
+
+  unstub rbenv-help
 }
 
 @test "not enough arguments rbenv-uninstall" {
+  stub rbenv-help 'echo "Usage: rbenv uninstall"'
+
   run rbenv-uninstall
   assert_failure
   assert_output_contains 'Usage: rbenv uninstall'
+
+  unstub rbenv-help
 }
 
 @test "too many arguments for rbenv-uninstall" {
+  stub rbenv-help 'echo "Usage: rbenv uninstall"'
+
   run rbenv-uninstall 2.1.1 2.1.2
   assert_failure
   assert_output_contains 'Usage: rbenv uninstall'
+
+  unstub rbenv-help
 }
 
 @test "show help for rbenv-uninstall" {
+  stub rbenv-help 'echo "Usage: rbenv uninstall"'
+
   run rbenv-uninstall -h
   assert_success
   assert_output_contains 'Usage: rbenv uninstall'
+
+  unstub rbenv-help
 }

--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -154,7 +154,7 @@ OUT
 
 @test "not enough arguments for rbenv-install" {
   stub_ruby_build
-  stub rbenv-help 'install : echo "Usage: rbenv install"'
+  stub rbenv-help 'install : true'
 
   run rbenv-install
   assert_failure
@@ -163,7 +163,7 @@ OUT
 
 @test "too many arguments for rbenv-install" {
   stub_ruby_build
-  stub rbenv-help 'install : echo "Usage: rbenv install"'
+  stub rbenv-help 'install : true'
 
   run rbenv-install 2.1.1 2.1.2
   assert_failure
@@ -172,7 +172,7 @@ OUT
 
 @test "show help for rbenv-install" {
   stub_ruby_build
-  stub rbenv-help 'install : echo "Usage: rbenv install"'
+  stub rbenv-help 'install : true'
 
   run rbenv-install -h
   assert_success
@@ -185,7 +185,7 @@ OUT
 }
 
 @test "not enough arguments rbenv-uninstall" {
-  stub rbenv-help 'uninstall : echo "Usage: rbenv uninstall"'
+  stub rbenv-help 'uninstall : true'
 
   run rbenv-uninstall
   assert_failure
@@ -193,7 +193,7 @@ OUT
 }
 
 @test "too many arguments for rbenv-uninstall" {
-  stub rbenv-help 'uninstall : echo "Usage: rbenv uninstall"'
+  stub rbenv-help 'uninstall : true'
 
   run rbenv-uninstall 2.1.1 2.1.2
   assert_failure
@@ -201,7 +201,7 @@ OUT
 }
 
 @test "show help for rbenv-uninstall" {
-  stub rbenv-help 'uninstall : echo "Usage: rbenv uninstall"'
+  stub rbenv-help 'uninstall : true'
 
   run rbenv-uninstall -h
   assert_success


### PR DESCRIPTION
The sed fallback was necessary before rbenv 0.4.0, which has been out for 2.5 years. I think it's time we can remove the fallback and just rely on rbenv-help.