### PR TITLE
37signals renamed themselves to Basecamp, so update sponsor in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ mirror and use official URLs instead. You can force ruby-build to bypass the
 mirror by setting the `RUBY_BUILD_SKIP_MIRROR` environment variable.
 
 The official ruby-build download mirror is sponsored by
-[37signals](http://37signals.com/).
+[Basecamp](https://basecamp.com/).
 
 ### Package download caching
 


### PR DESCRIPTION
See https://37signals.com/ for announcement post.