### PR TITLE
Rubygems added a redirect on their main domain, so use it as the canonical download URL

### DIFF
--- a/share/ruby-build/1.8.6-p383
+++ b/share/ruby-build/1.8.6-p383
@@ -1,3 +1,3 @@
 require_gcc
 install_package "ruby-1.8.6-p383" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p383.tar.gz#cea6c67f737727007ec89d1c93fd7d0dba035220f981706091b8642d7a43c03a" auto_tcltk standard
-install_package "rubygems-1.3.7" "https://rubygems.global.ssl.fastly.net/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby
+install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.6-p420
+++ b/share/ruby-build/1.8.6-p420
@@ -1,3 +1,3 @@
 require_gcc
 install_package "ruby-1.8.6-p420" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.6-p420.tar.gz#118e6f24afce8e8a10dced23635168e58da6c9121a21f120c82f425d40a1e321" auto_tcltk standard
-install_package "rubygems-1.3.7" "https://rubygems.global.ssl.fastly.net/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby
+install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.8.7-p249
+++ b/share/ruby-build/1.8.7-p249
@@ -1,3 +1,3 @@
 require_gcc
 install_package "ruby-1.8.7-p249" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p249.tar.gz#a969f5ec00f096f01650bfa594bc408f2e5cfc3de21b533ab62b4f29eb8ca653" auto_tcltk standard
-install_package "rubygems-1.6.2" "https://rubygems.global.ssl.fastly.net/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby
+install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p302
+++ b/share/ruby-build/1.8.7-p302
@@ -1,3 +1,3 @@
 require_gcc
 install_package "ruby-1.8.7-p302" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p302.tar.gz#5883df5204de70762602ce885b18c8bf6c856d33298c35df9151031b2ce044a1" auto_tcltk standard
-install_package "rubygems-1.6.2" "https://rubygems.global.ssl.fastly.net/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby
+install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p334
+++ b/share/ruby-build/1.8.7-p334
@@ -1,3 +1,3 @@
 require_gcc
 install_package "ruby-1.8.7-p334" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p334.tar.gz#68f68d6480955045661fab3be614c504bfcac167d070c6fdbfc9dbe2c5444bc0" auto_tcltk standard
-install_package "rubygems-1.6.2" "https://rubygems.global.ssl.fastly.net/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby
+install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p352
+++ b/share/ruby-build/1.8.7-p352
@@ -1,3 +1,3 @@
 require_gcc
 install_package "ruby-1.8.7-p352" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p352.tar.gz#2325b9f9ab2af663469d057c6a1ef59d914a649808e9f6d1a4877c8973c2dad0" auto_tcltk standard
-install_package "rubygems-1.6.2" "https://rubygems.global.ssl.fastly.net/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby
+install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p357
+++ b/share/ruby-build/1.8.7-p357
@@ -1,3 +1,3 @@
 require_gcc
 install_package "ruby-1.8.7-p357" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p357.tar.gz#2fdcac4eb37b2eba1a4eef392a2922e07a9222fc86d781d92154d716434b962c" auto_tcltk standard
-install_package "rubygems-1.6.2" "https://rubygems.global.ssl.fastly.net/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby
+install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p358
+++ b/share/ruby-build/1.8.7-p358
@@ -1,3 +1,3 @@
 require_gcc
 install_package "ruby-1.8.7-p358" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p358.tar.gz#9e0856d58830e08f1e38233947d859898ae09d4780cb1a502108e41308de33cb" auto_tcltk standard
-install_package "rubygems-1.6.2" "https://rubygems.global.ssl.fastly.net/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby
+install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p370
+++ b/share/ruby-build/1.8.7-p370
@@ -1,3 +1,3 @@
 require_gcc
 install_package "ruby-1.8.7-p370" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p370.tar.gz#bcd8db47adf6f5e3822b60a04785eedb1b97d41fbd7cb595d02759faa36581c6" auto_tcltk standard
-install_package "rubygems-1.6.2" "https://rubygems.global.ssl.fastly.net/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby
+install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p371
+++ b/share/ruby-build/1.8.7-p371
@@ -1,3 +1,3 @@
 require_gcc
 install_package "ruby-1.8.7-p371" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p371.tar.gz#e60a322f8f2a616eba01651f5ab620e7e48e4f8adfe711aec61cc74a91d54d3c" auto_tcltk standard
-install_package "rubygems-1.6.2" "https://rubygems.global.ssl.fastly.net/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby
+install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p374
+++ b/share/ruby-build/1.8.7-p374
@@ -1,3 +1,3 @@
 require_gcc
 install_package "ruby-1.8.7-p374" "https://cache.ruby-lang.org/pub/ruby/1.8/ruby-1.8.7-p374.tar.gz#876eeeaaeeab10cbf4767833547d66d86d6717ef48fd3d89e27db8926a65276c" auto_tcltk standard
-install_package "rubygems-1.6.2" "https://rubygems.global.ssl.fastly.net/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby
+install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.8.7-p375
+++ b/share/ruby-build/1.8.7-p375
@@ -1,3 +1,3 @@
 require_gcc
 install_svn "ruby-1.8.7-p375" "http://svn.ruby-lang.org/repos/ruby/branches/ruby_1_8_7" "44351" autoconf auto_tcltk standard
-install_package "rubygems-1.6.2" "https://rubygems.global.ssl.fastly.net/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby
+install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/1.9.1-p378
+++ b/share/ruby-build/1.9.1-p378
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.1-p378" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p378.tar.gz#b2960c330aa097c0cf90157a3133c6553ccdf8198e4c717c72cbe87c7f277547"
-install_package "rubygems-1.3.7" "https://rubygems.global.ssl.fastly.net/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby
+install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.1-p430
+++ b/share/ruby-build/1.9.1-p430
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.1-p430" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p430.tar.gz#6d28120e792a4a1cf32dd5f90c1643ecb48760157322a1bb267dd784d14fcb3a"
-install_package "rubygems-1.3.7" "https://rubygems.global.ssl.fastly.net/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby
+install_package "rubygems-1.3.7" "https://rubygems.org/rubygems/rubygems-1.3.7.tgz#388b90ae6273f655507b10c8ba6bee9ea72e7d49c3e610025531cb8c3ba67c9d" ruby

--- a/share/ruby-build/1.9.2-p0
+++ b/share/ruby-build/1.9.2-p0
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.2-p0" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p0.tar.gz#8c0c4e261a921b5c406bf9e76ac23bf3c915651534e9d1b9e8c5d0bee4a7285c"
-install_package "rubygems-1.8.23" "https://rubygems.global.ssl.fastly.net/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby
+install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.2-p180
+++ b/share/ruby-build/1.9.2-p180
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.2-p180" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p180.tar.gz#9027a5abaaadc2af85005ed74aeb628ce2326441874bf3d4f1a842663cde04f4"
-install_package "rubygems-1.8.23" "https://rubygems.global.ssl.fastly.net/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby
+install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.2-p290
+++ b/share/ruby-build/1.9.2-p290
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.2-p290" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p290.tar.gz#1cc817575c4944d3d78959024320ed1d5b7c2b4931a855772dacad7c3f6ebd7e"
-install_package "rubygems-1.8.23" "https://rubygems.global.ssl.fastly.net/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby
+install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.2-p318
+++ b/share/ruby-build/1.9.2-p318
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.2-p318" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p318.tar.gz#891f707714cb7585ffc76dfaf855e4fcd5b2c0a64655b62d9b23b6a3985a2749"
-install_package "rubygems-1.8.23" "https://rubygems.global.ssl.fastly.net/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby
+install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.2-p320
+++ b/share/ruby-build/1.9.2-p320
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.2-p320" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p320.tar.gz#39a1f046e8756c1885cde42b234bc608196e50feadf1d0f202f7634f4a4b1245"
-install_package "rubygems-1.8.23" "https://rubygems.global.ssl.fastly.net/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby
+install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.2-p326
+++ b/share/ruby-build/1.9.2-p326
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_svn "ruby-1.9.2-p326" "http://svn.ruby-lang.org/repos/ruby/branches/ruby_1_9_2" "44353" autoconf standard
-install_package "rubygems-1.8.23" "https://rubygems.global.ssl.fastly.net/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby
+install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.2-p330
+++ b/share/ruby-build/1.9.2-p330
@@ -1,5 +1,5 @@
 require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.2-p330" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.2-p330.tar.gz#23ef45fdaecc5d6c7b4e9e2d51b23817fc6aa8225a20f123f7fa98760e8b5ca9"
-install_package "rubygems-1.8.23" "https://rubygems.global.ssl.fastly.net/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby
+install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby
 

--- a/share/ruby-build/1.9.3-p0
+++ b/share/ruby-build/1.9.3-p0
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p0" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p0.tar.gz#3b910042e3561f4296fd95d96bf30322e53eecf083992e5042a7680698cfa34e"
-install_package "rubygems-1.8.23" "https://rubygems.global.ssl.fastly.net/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby
+install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.3-p125
+++ b/share/ruby-build/1.9.3-p125
@@ -1,4 +1,4 @@
 [ -n "$CC" ] || export CC=cc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-p125" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p125.tar.gz#8b3c035cf4f0ad6420f447d6a48e8817e5384d0504514939aeb156e251d44cce"
-install_package "rubygems-1.8.23" "https://rubygems.global.ssl.fastly.net/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby
+install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/1.9.3-preview1
+++ b/share/ruby-build/1.9.3-preview1
@@ -1,4 +1,4 @@
 require_gcc
 install_package "yaml-0.1.6" "http://pyyaml.org/download/libyaml/yaml-0.1.6.tar.gz#7da6971b4bd08a986dd2a61353bc422362bd0edcc67d7ebaac68c95f74182749" --if needs_yaml
 install_package "ruby-1.9.3-preview1" "https://cache.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-preview1.tar.gz#75c2dd57cabd67d8078a61db4ae86b22dc6f262b84460e5b95a0d8a327b36642"
-install_package "rubygems-1.8.23" "https://rubygems.global.ssl.fastly.net/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby
+install_package "rubygems-1.8.23" "https://rubygems.org/rubygems/rubygems-1.8.23.tgz#e4a1c6bbaac411eaab94deae78228b7584033a1f10a022f52bffa9613aa29061" ruby

--- a/share/ruby-build/rbx-1.2.4
+++ b/share/ruby-build/rbx-1.2.4
@@ -1,3 +1,3 @@
 require_llvm 2.8
 install_package "rubinius-1.2.4" "http://asset.rubini.us/rubinius-1.2.4-20110705.tar.gz#d474fb6f50292bff5211aaa80b1cead1fb3ed5c7c49223c51fddb8ffc5c3f23d" rbx
-install_package "rubygems-1.6.2" "https://rubygems.global.ssl.fastly.net/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby
+install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/ree-1.8.7-2011.03
+++ b/share/ruby-build/ree-1.8.7-2011.03
@@ -1,3 +1,3 @@
 require_gcc
 install_package "ruby-enterprise-1.8.7-2011.03" "https://rubyenterpriseedition.googlecode.com/files/ruby-enterprise-1.8.7-2011.03.tar.gz#0c0ddbc43b3aef49686db27e761e55a23437f12e1f00b6fe55d94724637bff6b" ree_installer
-install_package "rubygems-1.6.2" "https://rubygems.global.ssl.fastly.net/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby
+install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/ree-1.8.7-2011.12
+++ b/share/ruby-build/ree-1.8.7-2011.12
@@ -1,3 +1,3 @@
 require_gcc
 install_package "ruby-enterprise-1.8.7-2011.12" "https://rubyenterpriseedition.googlecode.com/files/ruby-enterprise-1.8.7-2011.12.tar.gz#9a8efc4befc136e17a1360de549aac9e79283c7238a13215350720e4393c5da2" ree_installer
-install_package "rubygems-1.6.2" "https://rubygems.global.ssl.fastly.net/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby
+install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby

--- a/share/ruby-build/ree-1.8.7-2012.01
+++ b/share/ruby-build/ree-1.8.7-2012.01
@@ -1,3 +1,3 @@
 require_gcc
 install_package "ruby-enterprise-1.8.7-2012.01" "https://rubyenterpriseedition.googlecode.com/files/ruby-enterprise-1.8.7-2012.01.tar.gz#c0c4779fc473fc9843c0008acfbae2e2bdf3472b454c7fe6ff0ac4139a691e65" ree_installer
-install_package "rubygems-1.6.2" "https://rubygems.global.ssl.fastly.net/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby
+install_package "rubygems-1.6.2" "https://rubygems.org/rubygems/rubygems-1.6.2.tgz#cb5261818b931b5ea2cb54bc1d583c47823543fcf9682f0d6298849091c1cea7" ruby


### PR DESCRIPTION
Swap from directly using CDN to https://rubygems.org, which just redirects to CDN (but then allows for easy change of CDN in future).