### PR TITLE
Ruby 2.2.3, Ruby 2.1.7 and Ruby 2.0.0-p647

### DIFF
--- a/share/ruby-build/2.0.0-p647
+++ b/share/ruby-build/2.0.0-p647
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.1p" "https://www.openssl.org/source/openssl-1.0.1p.tar.gz#bd5ee6803165c0fb60bbecbacacf244f1f90d2aa0d71353af610c29121e9b2f1" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.2.3" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.3.tar.gz#df795f2f99860745a416092a4004b016ccf77e8b82dec956b120f18bdc71edce" ldflags_dirs standard verify_openssl
+install_package "ruby-2.0.0-p647" "https://cache.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p647.tar.gz#c88aaf5b4ec72e2cb7d290ff854f04d135939f6134f517002a9d65d5fc5e5bec" standard verify_openssl

--- a/share/ruby-build/2.1.7
+++ b/share/ruby-build/2.1.7
@@ -1,0 +1,2 @@
+install_package "openssl-1.0.1p" "https://www.openssl.org/source/openssl-1.0.1p.tar.gz#bd5ee6803165c0fb60bbecbacacf244f1f90d2aa0d71353af610c29121e9b2f1" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.1.7" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.7.tar.gz#" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.1.7
+++ b/share/ruby-build/2.1.7
@@ -1,2 +1,2 @@
 install_package "openssl-1.0.1p" "https://www.openssl.org/source/openssl-1.0.1p.tar.gz#bd5ee6803165c0fb60bbecbacacf244f1f90d2aa0d71353af610c29121e9b2f1" mac_openssl --if has_broken_mac_openssl
-install_package "ruby-2.1.7" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.7.tar.gz#" ldflags_dirs standard verify_openssl
+install_package "ruby-2.1.7" "https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.7.tar.gz#f59c1596ac39cc7e60126e7d3698c19f482f04060674fdfe0124e1752ba6dd81" ldflags_dirs standard verify_openssl

--- a/share/ruby-build/2.2.3
+++ b/share/ruby-build/2.2.3
@@ -1,0 +1,2 @@
+install_package "openssl-1.0.1p" "https://www.openssl.org/source/openssl-1.0.1p.tar.gz#bd5ee6803165c0fb60bbecbacacf244f1f90d2aa0d71353af610c29121e9b2f1" mac_openssl --if has_broken_mac_openssl
+install_package "ruby-2.2.3" "https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.3.tar.gz#" ldflags_dirs standard verify_openssl


### PR DESCRIPTION
We released stable and old stable version of ruby.

 * https://www.ruby-lang.org/en/news/2015/08/18/ruby-2-0-0-p647-released/
 * https://www.ruby-lang.org/en/news/2015/08/18/ruby-2-1-7-released/
 * https://www.ruby-lang.org/en/news/2015/08/18/ruby-2-2-3-released/
