### PR TITLE
Add JRuby 9.0.2.0+graal-dev

### DIFF
--- a/share/ruby-build/jruby-9.0.2.0+graal-dev
+++ b/share/ruby-build/jruby-9.0.2.0+graal-dev
@@ -1,0 +1,1 @@
+install_package "jruby-9.0.2.0-SNAPSHOT" "http://lafo.ssw.uni-linz.ac.at/graalvm/jruby-dist-9.0.2.0-SNAPSHOT+graal-$(graal_architecture)-bin.tar.gz" jruby

--- a/share/ruby-build/jruby-master+graal-dev
+++ b/share/ruby-build/jruby-master+graal-dev
@@ -1,0 +1,1 @@
+install_package "jruby-master" "http://lafo.ssw.uni-linz.ac.at/graalvm/jruby-dist-master+graal-$(graal_architecture)-bin.tar.gz" jruby


### PR DESCRIPTION
the old JRuby 9.0.0.0+graal-dev installs outdated version