### PR TITLE
Remove license from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,28 +212,3 @@ Please see the [ruby-build wiki][wiki] for solutions to common problems.
 If you can't find an answer on the wiki, open an issue on the [issue
 tracker](https://github.com/sstephenson/ruby-build/issues). Be sure to include
 the full build log for build failures.
-
-
-### License
-
-(The MIT License)
-
-Copyright (c) 2012-2013 Sam Stephenson
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.


### PR DESCRIPTION
LICENSE already exists as its own file (https://github.com/sstephenson/ruby-build/blob/master/LICENSE)