### PR TITLE
TRAVIS_COMMIT_RANGE is correct now

### DIFF
--- a/script/test
+++ b/script/test
@@ -4,11 +4,6 @@ set -e
 STATUS=0
 bats ${CI:+--tap} test || STATUS="$?"
 
-if [ "${TRAVIS_PULL_REQUEST:-false}" != "false" ] &&  [ -z "$TRAVIS_COMMIT_RANGE" ]; then
-  first_sha="$(curl -fsSL https://github.com/${TRAVIS_REPO_SLUG}/pull/${TRAVIS_PULL_REQUEST}.patch | head -1 | awk '{print $2}')"
-  export TRAVIS_COMMIT_RANGE="${first_sha}^..${TRAVIS_COMMIT}"
-fi
-
 if [ "$TRAVIS_SECURE_ENV_VARS" = "true" ]; then
   ./script/mirror update "$TRAVIS_COMMIT_RANGE"
 elif [ "${TRAVIS_PULL_REQUEST:-false}" != "false" ]; then


### PR DESCRIPTION
According to https://github.com/travis-ci/travis-ci/issues/1719 (closed by https://github.com/travis-ci/travis-core/pull/383), the behavior of $TRAVIS_COMMIT_RANGE should be correct now. We should be able to use it directly.