### PR TITLE
Allow for space-separated LDFLAGS

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -968,11 +968,13 @@ build_package_verify_openssl() {
 }
 
 # Ensure that directories listed in LDFLAGS exist
+# $LDFLAGS must be in format '-L /path/' or '-L/path/'
 build_package_ldflags_dirs() {
   local arg
   for arg in $LDFLAGS; do
     case "$arg" in
-    -L* ) mkdir -p "${arg#-L}" ;;
+    -L ) ;;
+    * ) mkdir -p "${arg#-L}" ;;
     esac
   done
 }


### PR DESCRIPTION
Prevented errors caused by a space between `-L` and the path by not creating a directory if the arg is `-L`

The base case of the switch statement will be called with either `-L/path/` or `/path/`. 
`mkdir` will then be called with that argument after the `-L` has been removed.

Fixes https://github.com/sstephenson/ruby-build/issues/829

P.s. this is my first pull request to an open source repo :-)